### PR TITLE
configure.ac: check for bash-4.4 pkg-config file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,13 @@ AC_ARG_WITH([bashdir],
     [directory containing preconfigured bash sources])],
   [bashdir="$withval"],
   [bashdir=no])
+if test "x$PKG_CONFIG" != xno ; then
+  PKG_CHECK_EXISTS([bash], [
+    if test "x$bashdir" = xno ; then
+      bashdir=`$PKG_CONFIG --variable=headersdir bash`
+    fi
+  ])
+fi
 AC_CACHE_CHECK([for a bash source tree],
   [ax_cv_dir_bash_sources], [
 ax_cv_dir_bash_sources=no


### PR DESCRIPTION
Apparently, if you run `make install-headers` in bash-4.4 build, the headers and a pkg-config gets installed!

Also see: https://src.fedoraproject.org/rpms/bash/pull-request/2