### PR TITLE
circle_init_builtin: added missing return value

### DIFF
--- a/src/circle-init.c
+++ b/src/circle-init.c
@@ -171,6 +171,8 @@ circle_init_builtin (WORD_LIST *list)
   for (func = all_circle_builtins; *func; func++)
     if (load_circle_builtin(*func) != EXECUTION_SUCCESS)
       return EXECUTION_FAILURE;
+
+  return EXECUTION_SUCCESS;
 }
 
 /* Define the documentation for the circle_init builtin. */


### PR DESCRIPTION
Found by OpenSuse Build bot [here](https://github.com/lanl/MPI-Bash/files/1461922/_log.txt).
