### PR TITLE
AC_SUBST an empty @program_suffix@ when configure sets it as NONE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,9 @@ if test "x$ax_cv_link_libcircle" != xyes ; then
 fi
 
 # Honor the program suffix when generating commands/mb*.
+if test "x$program_suffix" = xNONE ; then
+  program_suffix=""
+fi
 AC_SUBST([program_suffix])
 
 # Generate Makefiles and other files.


### PR DESCRIPTION
The `configure` generated by Autotools (at least on my system - `autoconf 2.69`, `automake 1.15.1`) was setting `$program_suffix` to `"NONE"` (rather than `""`, as it should be for *nix). This caused the shebang-line in the scripts in `commands/` dir to be `#! /usr/bin/env mpibashNONE`. This commit ensures `$program_suffix` gets converted to "" whenever it is "NONE".