### PR TITLE
circle-init: Avoid implicit declaration of execute_shell_function

### DIFF
--- a/src/circle-init.c
+++ b/src/circle-init.c
@@ -5,6 +5,7 @@
  *********************************************************/
 
 #include "circlebash.h"
+#include "execute_cmd.h"
 
 /* Define our library-local variables in an ad hoc namespace. */
 SHELL_VAR *circlebash_create_func = NULL;   /* User-defined callback function for CIRCLE_cb_create. */


### PR DESCRIPTION
By including "execute_cmd.h".  This prevents a build failure with future compilers which do not support implicit function declarations by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
